### PR TITLE
屏幕旋转后，坐标计算方法也需要更新

### DIFF
--- a/lv_drivers/indev/evdev.c
+++ b/lv_drivers/indev/evdev.c
@@ -231,10 +231,17 @@ void evdev_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
       data->point.x = 0;
     if(data->point.y < 0)
       data->point.y = 0;
+#if (SSTAR_GFX_ROTATE_ANGLE == 1) || (SSTAR_GFX_ROTATE_ANGLE == 3)
+    if(data->point.x >= drv->disp->driver->ver_res)
+      data->point.x = drv->disp->driver->ver_res - 1;
+    if(data->point.y >= drv->disp->driver->hor_res)
+      data->point.y = drv->disp->driver->hor_res - 1;
+#else
     if(data->point.x >= drv->disp->driver->hor_res)
       data->point.x = drv->disp->driver->hor_res - 1;
     if(data->point.y >= drv->disp->driver->ver_res)
       data->point.y = drv->disp->driver->ver_res - 1;
+#endif
 
     return ;
 }


### PR DESCRIPTION
首先感谢作者，贡献了这么棒的代码！！
在调试过程中发现，屏幕显示旋转后，触摸功能异常，表现为部分区域触摸时候，实际上是点击的其他位置。跟踪代码后发现，是屏幕旋转后，坐标的限制条件没有跟着变导致的。
目前这样修改后，触摸坐标也正常了